### PR TITLE
Include Poynting Vector calculation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -66,6 +66,7 @@ dependencies:
 
   # extra
   - gdsfactory
+  - jaxlib
   #- mpb
   #- nomkl
   #- pymeep=*=mpi_mpich_*
@@ -85,8 +86,7 @@ dependencies:
 
     # jax
     - jax
-    - jaxlib
-    - klujax
+    # - klujax -> install problems
 
     # dev
     - autodoc-pydantic

--- a/tests/nbs/poynting.ipynb
+++ b/tests/nbs/poynting.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import meow as mw\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.style.use(\"default\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preparation\n",
+    "let's perform a mode simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "length = 10.0\n",
+    "box = mw.Box(\n",
+    "    x_min=-0.22,\n",
+    "    x_max=0.22,\n",
+    "    y_min=0,\n",
+    "    y_max=0.22,\n",
+    "    z_min=0.0,\n",
+    "    z_max=length,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct = mw.Structure(material=mw.silicon, geometry=box)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell = mw.Cell(\n",
+    "    structures=[struct],\n",
+    "    mesh=mw.Mesh2d(\n",
+    "        x = np.linspace(-1, 1, 101),\n",
+    "        y = np.linspace(-1, 1, 101),\n",
+    "    ),\n",
+    "    z_min=0.0,\n",
+    "    z_max=length,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env = mw.Environment(wl=1.55, T=25.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cs = mw.CrossSection(\n",
+    "    cell=cell,\n",
+    "    env=env,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mode = mw.compute_modes(cs, 1)[0]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get the Poynting Vector\n",
+    "calculating the poynting vector is performed under the hood, when one of `Px`,`Py` or `Pz` is requested"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mode.Px.shape"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It can be used with the native visualization functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mw.visualize(mode, fields=[\"Ex\"])\n",
+    "mw.visualize(mode, fields=[\"Pz\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "8cb1a8d1c3ece4eb1e4592eaec04207f7b73f2abcb1f254721941c0090e83ef8"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
to avoid recalculation caching in private attributes is used.
It uses `pydantic.PrivateAttr` to conform to pydantic. I am not sure, that this is a beautiful way to do it. It should not be saved when serializing/deserializing.
Addresses task 1 of #6.

I had to move `jaxlib` to conda/mamba install and remove `klujax` from the `environment.yml`, because it doesn't install properly on macos at the moment. A pull request to fix the problem is open here https://github.com/flaport/klujax/pull/1.