### PR TITLE
Add mode area calculation (and integration util)

### DIFF
--- a/meow/integrate.py
+++ b/meow/integrate.py
@@ -1,0 +1,31 @@
+from scipy.interpolate import RegularGridInterpolator
+from scipy.integrate import dblquad, simpson
+
+
+def integrate_interpolate_2d(x, y, data, extent=None):
+    """
+    First the data on the given grid is interpolated and then integrated using `scipy.dblquad`.
+    This procedure is best suited if one wants to integrate over a (small) region of interest that can be placed at off-grid positions"""
+    interp = RegularGridInterpolator((x, y), data)
+    if extent is None:
+        extent = [[min(x), max(x)], [min(y), max(y)]]
+
+    def integrable(x, y):
+        return interp((x, y))
+
+    return dblquad(
+        integrable,
+        extent[0][0],
+        extent[0][1],
+        lambda x: extent[1][0],
+        lambda x: extent[1][1],
+        epsabs=1,
+        epsrel=0.001,
+    )[0]
+
+
+def integrate_2d(x, y, data):
+    """much simpler integration over the full grid"""
+    int1 = simpson(data, y)
+    int2 = simpson(int1, x)
+    return int2

--- a/tests/nbs/poynting_and_area.ipynb
+++ b/tests/nbs/poynting_and_area.ipynb
@@ -100,7 +100,8 @@
    "metadata": {},
    "source": [
     "## get the Poynting Vector\n",
-    "calculating the poynting vector is performed under the hood, when one of `Px`,`Py` or `Pz` is requested"
+    "$$ \\vec{P} = \\vec{E} \\times \\vec{H} $$\n",
+    "calculating the poynting vector is performed under the hood, when one of `Px`,`Py` or `Pz` is requested\n"
    ]
   },
   {
@@ -131,10 +132,78 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mode area calculation\n",
+    "\n",
+    "$$ A_{eff} = \\frac{\\left(\\int|\\vec{E}|^2dA\\right)^2}{\\int|\\vec{E}|^4dA} $$"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "mode.A\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare to integrate interpolate"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also itegrate over the modal fields and derived quantities by first finding a suitable interpolation function. This is computationally much more expensive and not necessarily more accurate. It however provides tha benefit, that the integration can be performed over a region of interest, not limited to integer mesh positions. \n",
+    "\n",
+    "For the calculation of the effective mode area this is however not beneficial. Just as a demonstration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.linalg import norm\n",
+    "from meow.integrate import integrate_interpolate_2d as integrate_2d\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vecE = np.stack([mode.Ex, mode.Ey, mode.Ez], axis=-1)\n",
+    "E_sq = norm(vecE, axis=-1, ord=2)\n",
+    "E_qu = E_sq**2\n",
+    "x = mode.cs.mesh.x_\n",
+    "y = mode.cs.mesh.y_\n",
+    "integrate_2d(x,y,E_sq)**2 / integrate_2d(x,y,E_qu)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see one (or both) of the methods are inacurate. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],


### PR DESCRIPTION
Adding the calculation of the effective Mode area as described in #6. Additionally a convenience function to integrate over 2D data sampled on a rectlinear grid is provided, which should make adapting the other quantities to non-equidistant grids easier.