### PR TITLE
Convenience functions for Mode arithmetics

### DIFF
--- a/meow/mode.py
+++ b/meow/mode.py
@@ -3,6 +3,7 @@
 import pickle
 from itertools import product
 from typing import Any, List, Tuple
+import numbers
 
 import numpy as np
 from pydantic import Field, PrivateAttr
@@ -192,6 +193,49 @@ class Mode(BaseModel):
     def load(cls, filename):
         with open(filename, "rb") as file:
             return pickle.load(file)
+
+    def __add__(self, other):
+        if not isinstance(other, Mode):
+            raise TypeError(f"unsupported operand type(s) for +: 'Mode' and '{type(other).__name__}'")
+        new_mode = Mode(
+            neff=np.mean([self.neff, other.neff]),
+            cs=self.cs,
+            Ex=self.Ex + other.Ex,
+            Ey=self.Ey + other.Ey,
+            Ez=self.Ez + other.Ez,
+            Hx=self.Hx + other.Hx,
+            Hy=self.Hy + other.Hy,
+            Hz=self.Hz + other.Hz,
+        )
+        return new_mode
+    
+    def __mul__(self, other):
+        if not isinstance(other, numbers.Number):
+            raise TypeError(f"unsupported operand type(s) for *: 'Mode' and '{type(other).__name__}'")
+        new_mode = Mode(
+            neff=self.neff,
+            cs=self.cs,
+            Ex=self.Ex * other,
+            Ey=self.Ey * other,
+            Ez=self.Ez * other,
+            Hx=self.Hx * other,
+            Hy=self.Hy * other,
+            Hz=self.Hz * other,
+        )
+        return new_mode
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, other):
+        if not isinstance(other, numbers.Number):
+            raise TypeError(f"unsupported operand type(s) for /: 'Mode' and '{type(other).__name__}'")
+        return self*(1/other)
+    
+    def __sub__(self, other):
+        if not isinstance(other, Mode):
+            raise TypeError(f"unsupported operand type(s) for -: 'Mode' and '{type(other).__name__}'")
+        return self + other*(-1)
+    
 
 
 Modes = List[Mode]

--- a/tests/test_mode_operators.py
+++ b/tests/test_mode_operators.py
@@ -1,0 +1,125 @@
+from meow import Mode
+
+
+MODE_DATA = {
+    "neff": {"real": 3.526228477887, "imag": -0.03995016558},
+    "Ex": [1,1],
+    "Ey": [2,2],
+    "Ez": [3,3],
+    "Hx": [1,1],
+    "Hy": [2,2],
+    "Hz": [3,3],
+    "cs": {
+        "cell": {
+            "structures": [
+                {
+                    "material": {
+                        "name": "SiO2",
+                        "params": {"wl": [1.2]},
+                        "n": {"real": [1.955], "imag": [0.0]},
+                    },
+                    "geometry": {
+                        "type": "Box",
+                        "x_min": -1.0,
+                        "x_max": 1.0,
+                        "y_min": 0.0,
+                        "y_max": 3.5,
+                        "z_min": -1.0,
+                        "z_max": 1.0,
+                    },
+                    "mesh_order": 5,
+                },
+                {
+                    "material": {
+                        "name": "SiO2",
+                        "params": {"wl": [1.2]},
+                        "n": {"real": [1.955], "imag": [0.0]},
+                    },
+                    "geometry": {
+                        "type": "Box",
+                        "x_min": -4.0,
+                        "x_max": 4.0,
+                        "y_min": -2.0,
+                        "y_max": 2.3,
+                        "z_min": -1.0,
+                        "z_max": 1.0,
+                    },
+                    "mesh_order": 5,
+                },
+                {
+                    "material": {
+                        "name": "Si",
+                        "params": {"wl": [1.2], "T": [38.0]},
+                        "n": {"real": [3.526617910662], "imag": [0.0]},
+                    },
+                    "geometry": {
+                        "type": "Box",
+                        "x_min": -0.75,
+                        "x_max": 0.75,
+                        "y_min": 0.0,
+                        "y_max": 3.0,
+                        "z_min": -1.0,
+                        "z_max": 1.0,
+                    },
+                    "mesh_order": 5,
+                },
+                {
+                    "material": {
+                        "name": "Si",
+                        "params": {"wl": [1.2], "T": [38.0]},
+                        "n": {"real": [3.526617910662], "imag": [0.0]},
+                    },
+                    "geometry": {
+                        "type": "Box",
+                        "x_min": -4.0,
+                        "x_max": 4.0,
+                        "y_min": 0.0,
+                        "y_max": 1.8,
+                        "z_min": -1.0,
+                        "z_max": 1.0,
+                    },
+                    "mesh_order": 5,
+                },
+            ],
+            "mesh": {
+                "x": [],
+                "y": [],
+                "angle_phi": 0.0,
+                "angle_theta": 0.0,
+                "bend_radius": 6000.0,
+                "bend_axis": 1,
+                "num_pml": [6, 6],
+            },
+            "z_min": -1.0,
+            "z_max": -1.0,
+        },
+        "env": {"wl": 1.2, "T": 38.0},
+    },
+}
+
+mode1 = Mode.parse_obj(MODE_DATA)
+mode2 = Mode.parse_obj(MODE_DATA)
+
+def test_multiply_modes():
+    """multiplying two modes objects is not supported and should raise a TypeError"""
+    try:
+        mode1*mode2
+        assert False
+    except TypeError:
+        pass
+
+def test_multiply_scalar():
+    assert (mode1*3).Ex[0,0] == 3
+
+def test_add_modes():
+    assert (mode1+mode2).Ex[0,0] == 2
+
+def test_substract_modes():
+    assert (mode1-mode2).Ex[0,0] == 0
+
+def test_divide_scalar():
+    assert (mode1/2).Ex[0,0] == 1/2
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__])


### PR DESCRIPTION
I added functionality to add and scale modes. Which comes in handy for converting even and odd supermodes into the individual modes of two adjacent waveguides