### PR TITLE
pin pydantic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ temp
 sandbox
 tests/nbs_fail
 
+log.txt
 # nbdev
 *.bak
 *.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
   "matplotlib",
   "numpy>=1.24",
-  "pydantic",
+  "pydantic<2",
   "sax>=0.8.4",
   "scipy",
   "shapely",


### PR DESCRIPTION
we need to pin pydantic<2 and make a new release, otherwise `pip install meow-sim` does not work