### PR TITLE
Implementation of Polygon2D variant for Geometry2D

### DIFF
--- a/meow/__init__.py
+++ b/meow/__init__.py
@@ -1,4 +1,4 @@
-""" MEOW: Modeling of Eigenmodes and Overlaps in Waveguides """
+"""MEOW: Modeling of Eigenmodes and Overlaps in Waveguides"""
 
 __author__ = "Floris Laporte"
 __version__ = "0.13.0"
@@ -28,6 +28,7 @@ from .geometries import Geometry2D as Geometry2D
 from .geometries import Geometry2DBase as Geometry2DBase
 from .geometries import Geometry3D as Geometry3D
 from .geometries import Geometry3DBase as Geometry3DBase
+from .geometries import Polygon2D as Polygon2D
 from .geometries import Prism as Prism
 from .geometries import Rectangle as Rectangle
 from .integrate import integrate_2d as integrate_2d

--- a/meow/geometries.py
+++ b/meow/geometries.py
@@ -93,8 +93,8 @@ class Polygon2D(Geometry2DBase):
 
         ax.add_patch(patch)
 
-        min_x, max_x = min(self.poly[:, 0]) - 0.5, max(self.poly[:, 0]) + 0.5
-        min_y, max_y = min(self.poly[:, 1]) - 0.5, max(self.poly[:, 1]) + 0.5
+        min_x, max_x = min(self.poly[:, 0]), max(self.poly[:, 0])
+        min_y, max_y = min(self.poly[:, 1]), max(self.poly[:, 1])
 
         extent_x = max_x - min_x
         extent_y = max_y - min_y


### PR DESCRIPTION
This pull request implements the Polygon2D variant of Geometry2D to allow direct drawing of arbitrary polygon in a 2D cross section.

Test with this example:
```python
import numpy as np

import meow as mw
from meow import (
    CrossSection,
    Environment,
    Mesh2D,
    Polygon2D,
    Structure2D,
    silicon,
)

array = np.array([[-1, 0], [1, 0], [0.2, 1], [-0.2, 1.0]])
poly = Polygon2D(poly=array)

env = Environment(wl=1.55, T=25.0)

structures = [
    Structure2D(
        material=silicon,
        geometry=poly,
    )
]

mesh = Mesh2D(
    x=np.linspace(-3, 3, 301),
    y=np.linspace(-3, 3, 301),
    num_pml=(0, 0),
    ez_interfaces=True,
)


cross_section = CrossSection(
    structures=structures,
    mesh=mesh,
    env=env,
)

mw.visualize(cross_section)

modes = mw.compute_modes(cross_section, num_modes=4)

mw.visualize(modes[0], fields=["Ex"])


```