### PR TITLE
Definition of plane_center for bend mode solving

### DIFF
--- a/meow/fde/tidy3d.py
+++ b/meow/fde/tidy3d.py
@@ -73,6 +73,7 @@ def compute_modes_tidy3d(
             freq=c / (cs.env.wl * 1e-6),
             mode_spec=mode_spec,
             precision=precision,
+            plane_center=(0.0, 0.0),
         )[:2]
     )
 

--- a/meow/fde/tidy3d.py
+++ b/meow/fde/tidy3d.py
@@ -73,7 +73,7 @@ def compute_modes_tidy3d(
             freq=c / (cs.env.wl * 1e-6),
             mode_spec=mode_spec,
             precision=precision,
-            plane_center=(0.0, 0.0),
+            plane_center=cs.mesh.plane_center,
         )[:2]
     )
 

--- a/meow/mesh.py
+++ b/meow/mesh.py
@@ -50,6 +50,14 @@ class Mesh2D(BaseModel):
             "always 1 (the global z axis)."
         ),
     )
+    plane_center: tuple[float, float] = Field(
+        default=(0.0, 0.0),
+        description=(
+            "If ``bend_radius`` is not ``None``, "
+            "the position of the plane corresponding along the circonference of the circle"
+        ),
+    )
+
     num_pml: tuple[NonNegativeInt, NonNegativeInt] = Field(
         default=(0, 0),
         description="Number of standard pml layers to add in the two tangential axes.",

--- a/tests/nbs/bend.ipynb
+++ b/tests/nbs/bend.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc6bb9cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import meow as mw\n",
+    "from meow import (\n",
+    "    CrossSection,\n",
+    "    Environment,\n",
+    "    Mesh2D,\n",
+    "    Polygon2D,\n",
+    "    Structure2D,\n",
+    "    silicon_oxide,\n",
+    ")\n",
+    "\n",
+    "mw.cache.disable_cache();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94b118e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "array = np.array([[-1, 0], [1, 0], [0.2, 1], [-0.2, 1.0]])\n",
+    "poly = Polygon2D(poly=array)\n",
+    "\n",
+    "env = Environment(wl=1.55, T=25.0)\n",
+    "\n",
+    "structures = [\n",
+    "    Structure2D(\n",
+    "        material=silicon_oxide,\n",
+    "        geometry=poly,\n",
+    "    )\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "425ea0c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = Mesh2D(\n",
+    "    x=np.linspace(-3, 3, 101),\n",
+    "    y=np.linspace(-3, 3, 101),\n",
+    "    num_pml=(6, 6),\n",
+    "    ez_interfaces=True,\n",
+    "    bend_axis=1,\n",
+    "    bend_radius=15.0,\n",
+    ")\n",
+    "\n",
+    "cross_section = CrossSection(\n",
+    "    structures=structures,\n",
+    "    mesh=mesh,\n",
+    "    env=env,\n",
+    ")\n",
+    "\n",
+    "mw.visualize(cross_section)\n",
+    "\n",
+    "modes = mw.compute_modes(cross_section, num_modes=4)\n",
+    "\n",
+    "mw.visualize(modes[0], fields=[\"Ex\"])\n",
+    "print(modes[0].neff)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e36a7267",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = Mesh2D(\n",
+    "    x=np.linspace(-3, 3, 101),\n",
+    "    y=np.linspace(-3, 3, 101),\n",
+    "    num_pml=(6, 6),\n",
+    "    ez_interfaces=True,\n",
+    "    bend_axis=1,\n",
+    "    bend_radius=20.0,\n",
+    "    plane_center=(5.0, 0.0),\n",
+    ")\n",
+    "\n",
+    "cross_section = CrossSection(\n",
+    "    structures=structures,\n",
+    "    mesh=mesh,\n",
+    "    env=env,\n",
+    ")\n",
+    "\n",
+    "mw.visualize(cross_section)\n",
+    "\n",
+    "modes = mw.compute_modes(cross_section, num_modes=4)\n",
+    "\n",
+    "mw.visualize(modes[0], fields=[\"Ex\"])\n",
+    "print(modes[0].neff * 20.0 / 15.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c830be4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = Mesh2D(\n",
+    "    x=np.linspace(-3, 3, 101),\n",
+    "    y=np.linspace(-3, 3, 101),\n",
+    "    num_pml=(6, 6),\n",
+    "    ez_interfaces=True,\n",
+    "    bend_axis=1,\n",
+    "    bend_radius=13.0,\n",
+    "    plane_center=(-2.0, 0.0),\n",
+    ")\n",
+    "\n",
+    "cross_section = CrossSection(\n",
+    "    structures=structures,\n",
+    "    mesh=mesh,\n",
+    "    env=env,\n",
+    ")\n",
+    "\n",
+    "mw.visualize(cross_section)\n",
+    "\n",
+    "modes = mw.compute_modes(cross_section, num_modes=4)\n",
+    "\n",
+    "mw.visualize(modes[0], fields=[\"Ex\"])\n",
+    "print(modes[0].neff * 13.0 / 15.0)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
It seems that for modal simulation tidy3d requires the definition of the center of the simulation.

I added a sensible default to the inner _compute_mode call, but right now this argument is not exposed.
Do you think it would be better to expose it, maybe as an additional attribute to the mesh object?