### PR TITLE
Fix top PML energy slice in is_pml_mode

### DIFF
--- a/src/meow/mode.py
+++ b/src/meow/mode.py
@@ -455,7 +455,7 @@ def is_pml_mode(mode: Mode, threshold: float) -> bool:
     m, n = ed.shape
     lft = ed[:numx, :]
     rgt = ed[m - numx :, :]
-    top = ed[numx : m - numx, n:numy]
+    top = ed[numx : m - numx, :numy]
     btm = ed[numx : m - numx, n - numy :]
     rest = ed[numx : m - numx, numy : n - numy]
     pml_sum = lft.sum() + rgt.sum() + top.sum() + btm.sum()


### PR DESCRIPTION
## Summary
- fix top-strip slicing in `is_pml_mode` so the y-top PML region is included
- replace the empty/incorrect slice `n:numy` with the intended top-strip slice `:numy`

## Why
The previous indexing skipped the top PML contribution, which could undercount PML energy and misclassify radiative/PML modes as guided.

## Validation
- pre-commit run --all-files