### PR TITLE
docs: update mkdocs-shadcn source to gdsfactory/mkdocs-shadcn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
   "ipywidgets>=8.0.0",
   "mkautodoc>=0.2.0",
   "mkdocs-autorefs>=1.3.0",
-  "mkdocs-shadcn @ git+https://github.com/flaport/mkdocs-shadcn.git",
+  "mkdocs-shadcn @ git+https://github.com/gdsfactory/mkdocs-shadcn.git",
   "mkdocs<2",
   "mkdocstrings[python]>=0.27.0",
   "mkinit>=1.1.0",


### PR DESCRIPTION
Update the `mkdocs-shadcn` dependency to point to `gdsfactory/mkdocs-shadcn` instead of the old `flaport/mkdocs-shadcn` location.

**Changes:**
- `pyproject.toml`: `mkdocs-shadcn @ git+https://github.com/flaport/mkdocs-shadcn.git` → `mkdocs-shadcn @ git+https://github.com/gdsfactory/mkdocs-shadcn.git`