### PR TITLE
fix: docs code blocks not rendering, clean up changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,37 @@
 <a id="0.15.0"></a>
 # [0.15.0](https://github.com/gdsfactory/meow/releases/tag/0.15.0) - 2026-03-15
 
-# What's Changed
-
 ## Bug Fixes
 
-- Fix top PML energy slice in is_pml_mode [#53](https://github.com/$OWNER/$REPOSITORY/pull/53)
-- fix eme r2l lossy projection [#52](https://github.com/$OWNER/$REPOSITORY/pull/52)
+- Fix top PML energy slice in is_pml_mode [#53](https://github.com/gdsfactory/meow/pull/53)
+- fix eme r2l lossy projection [#52](https://github.com/gdsfactory/meow/pull/52)
 
 ## Documentation
 
-- Big refactoring [#54](https://github.com/$OWNER/$REPOSITORY/pull/54)
-
-**Full Changelog**: https://github.com/gdsfactory/meow/compare/0.14.1...0.15.0
-
-[Changes][0.15.0]
-
+- Big refactoring [#54](https://github.com/gdsfactory/meow/pull/54)
 
 <a id="0.14.1"></a>
 # [0.14.1](https://github.com/gdsfactory/meow/releases/tag/0.14.1) - 2025-06-23
 
-# What's Changed
-
 ## Dependency Updates
 
-- bump sax [#50](https://github.com/$OWNER/$REPOSITORY/pull/50)
-
-**Full Changelog**: https://github.com/gdsfactory/meow/compare/0.14.0...0.14.1
-
-[Changes][0.14.1]
-
+- bump sax [#50](https://github.com/gdsfactory/meow/pull/50)
 
 <a id="0.14.0"></a>
 # [0.14.0](https://github.com/gdsfactory/meow/releases/tag/0.14.0) - 2025-06-20
 
-# What's Changed
-
 ## New
 
-- Bump sax + ruff + pyright refactoring [#49](https://github.com/$OWNER/$REPOSITORY/pull/49)
+- Bump sax + ruff + pyright refactoring [#49](https://github.com/gdsfactory/meow/pull/49)
 
 ## Other changes
 
-- Definition of plane_center for bend mode solving [#48](https://github.com/$OWNER/$REPOSITORY/pull/48)
-- Implementation of Polygon2D variant for Geometry2D [#47](https://github.com/$OWNER/$REPOSITORY/pull/47)
-- Change logo [#46](https://github.com/$OWNER/$REPOSITORY/pull/46)
-
-**Full Changelog**: https://github.com/gdsfactory/meow/compare/0.13.0...0.14.0
-
-[Changes][0.14.0]
-
+- Definition of plane_center for bend mode solving [#48](https://github.com/gdsfactory/meow/pull/48)
+- Implementation of Polygon2D variant for Geometry2D [#47](https://github.com/gdsfactory/meow/pull/47)
+- Change logo [#46](https://github.com/gdsfactory/meow/pull/46)
 
 <a id="0.13.0"></a>
 # [0.13.0](https://github.com/gdsfactory/meow/releases/tag/0.13.0) - 2025-04-13
-
-# What's Changed
 
 ## New
 
@@ -79,13 +56,8 @@
 - Update github workflows
 - Update github ci
 
-[Changes][0.13.0]
-
-
 <a id="0.12.0"></a>
 # [0.12.0](https://github.com/gdsfactory/meow/releases/tag/0.12.0) - 2025-02-13
-
-# What's Changed
 
 ## New
 
@@ -98,26 +70,16 @@
 - Merge pull request [#43](https://github.com/gdsfactory/meow/issues/43) from joamatab/numpy2_compat
 - Update to numpy2
 
-[Changes][0.12.0]
-
-
 <a id="0.11.2"></a>
 # [0.11.2](https://github.com/gdsfactory/meow/releases/tag/0.11.2) - 2024-08-06
-
-# What's Changed
 
 ## Bug Fixes
 
 - Merge pull request [#38](https://github.com/gdsfactory/meow/issues/38) from joamatab/patch-1
 - Merge branch 'main' into patch-1
 
-[Changes][0.11.2]
-
-
 <a id="0.11.1"></a>
 # [0.11.1](https://github.com/gdsfactory/meow/releases/tag/0.11.1) - 2024-08-04
-
-# What's Changed
 
 ## Dependency Updates
 
@@ -129,13 +91,8 @@
 - Better equality check
 - Don't use Self for now
 
-[Changes][0.11.1]
-
-
 <a id="0.11.0"></a>
 # [0.11.0](https://github.com/gdsfactory/meow/releases/tag/0.11.0) - 2024-06-20
-
-# What's Changed
 
 ## New
 
@@ -157,13 +114,8 @@
 
 - Exclusively support pydantic v2
 
-[Changes][0.11.0]
-
-
 <a id="0.10.0"></a>
 # [0.10.0](https://github.com/gdsfactory/meow/releases/tag/0.10.0) - 2024-06-15
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -174,13 +126,8 @@
 
 - Works for gdsfactory8
 
-[Changes][0.10.0]
-
-
 <a id="0.9.0"></a>
 # [0.9.0](https://github.com/gdsfactory/meow/releases/tag/0.9.0) - 2024-01-19
-
-# What's Changed
 
 ## New
 
@@ -195,37 +142,22 @@
 
 - Pin sax
 
-[Changes][0.9.0]
-
-
 <a id="0.8.1"></a>
 # [0.8.1](https://github.com/gdsfactory/meow/releases/tag/0.8.1) - 2023-09-19
-
-# What's Changed
 
 ## Dependency Updates
 
 - Bump tidy3d
 
-[Changes][0.8.1]
-
-
 <a id="0.8.0"></a>
 # [0.8.0](https://github.com/gdsfactory/meow/releases/tag/0.8.0) - 2023-09-05
-
-# What's Changed
 
 ## Dependency Updates
 
 - Bump sax dependency
 
-[Changes][0.8.0]
-
-
 <a id="0.7.3"></a>
 # [0.7.3](https://github.com/gdsfactory/meow/releases/tag/0.7.3) - 2023-08-30
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -236,38 +168,23 @@
 - Update dependencies
 - Bump pydantic to v2 using pydantic.v1
 
-[Changes][0.7.3]
-
-
 <a id="0.7.2"></a>
 # [0.7.2](https://github.com/gdsfactory/meow/releases/tag/0.7.2) - 2023-08-04
-
-# What's Changed
 
 ## Dependency Updates
 
 - Merge pull request [#31](https://github.com/gdsfactory/meow/issues/31) from joamatab/pin_pydantic
 - Pin pydantic
 
-[Changes][0.7.2]
-
-
 <a id="0.7.1"></a>
 # [0.7.1](https://github.com/gdsfactory/meow/releases/tag/0.7.1) - 2023-07-09
-
-# What's Changed
 
 ## Other changes
 
 - Explicit imports of objects in __init__
 
-[Changes][0.7.1]
-
-
 <a id="0.7.0"></a>
 # [0.7.0](https://github.com/gdsfactory/meow/releases/tag/0.7.0) - 2023-07-06
-
-# What's Changed
 
 ## New
 
@@ -309,13 +226,8 @@
 - Deprecate Mesh2d in favor of Mesh2D
 - Remove unused line
 
-[Changes][0.7.0]
-
-
 <a id="0.6.9"></a>
 # [0.6.9](https://github.com/gdsfactory/meow/releases/tag/0.6.9) - 2023-06-26
-
-# What's Changed
 
 ## New
 
@@ -325,13 +237,8 @@
 
 - Update meshing comparison
 
-[Changes][0.6.9]
-
-
 <a id="0.6.8"></a>
 # [0.6.8](https://github.com/gdsfactory/meow/releases/tag/0.6.8) - 2023-06-23
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -341,45 +248,25 @@
 
 - Improve ez boundaries by including them into Cell in stead of CrossSection
 
-[Changes][0.6.8]
-
-
 <a id="0.6.7"></a>
 # [0.6.7](https://github.com/gdsfactory/meow/releases/tag/0.6.7) - 2023-06-22
 
-
-
-[Changes][0.6.7]
-
-
 <a id="0.6.6"></a>
 # [0.6.6](https://github.com/gdsfactory/meow/releases/tag/0.6.6) - 2023-06-22
-
-# What's Changed
 
 ## Bug Fixes
 
 - Fix some meshing issues and normalize modes properly
 
-[Changes][0.6.6]
-
-
 <a id="0.6.5"></a>
 # [0.6.5](https://github.com/gdsfactory/meow/releases/tag/0.6.5) - 2023-06-19
-
-# What's Changed
 
 ## Bug Fixes
 
 - Fix material serialization/deserialization
 
-[Changes][0.6.5]
-
-
 <a id="0.6.4"></a>
 # [0.6.4](https://github.com/gdsfactory/meow/releases/tag/0.6.4) - 2023-06-19
-
-# What's Changed
 
 ## New
 
@@ -402,38 +289,23 @@
 - Tolerance to klu not being present
 - Use `Optional` instead of `|` to maintain compatibility to python<3.10
 
-[Changes][0.6.4]
-
-
 <a id="0.6.3"></a>
 # [0.6.3](https://github.com/gdsfactory/meow/releases/tag/0.6.3) - 2023-06-18
-
-# What's Changed
 
 ## New
 
 - Add field interpolation
 - Add lumerical dielectric interfaces
 
-[Changes][0.6.3]
-
-
 <a id="0.6.2"></a>
 # [0.6.2](https://github.com/gdsfactory/meow/releases/tag/0.6.2) - 2023-06-18
-
-# What's Changed
 
 ## Other changes
 
 - Proper mesh locations
 
-[Changes][0.6.2]
-
-
 <a id="0.6.1"></a>
 # [0.6.1](https://github.com/gdsfactory/meow/releases/tag/0.6.1) - 2023-06-17
-
-# What's Changed
 
 ## New
 
@@ -459,13 +331,8 @@
 - Minor visualization tweaks
 - Allow forcing Ez on dielectric boundaries
 
-[Changes][0.6.1]
-
-
 <a id="0.6.0"></a>
 # [0.6.0](https://github.com/gdsfactory/meow/releases/tag/0.6.0) - 2023-06-15
-
-# What's Changed
 
 ## New
 
@@ -479,13 +346,8 @@
 
 - Minor cleanup of Material internals
 
-[Changes][0.6.0]
-
-
 <a id="0.5.6"></a>
 # [0.5.6](https://github.com/gdsfactory/meow/releases/tag/0.5.6) - 2023-06-13
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -496,50 +358,30 @@
 - Allow specifying plot width to visualize modes
 - Reject pml modes when using meow
 
-[Changes][0.5.6]
-
-
 <a id="0.5.5"></a>
 # [0.5.5](https://github.com/gdsfactory/meow/releases/tag/0.5.5) - 2023-06-09
-
-# What's Changed
 
 ## Other changes
 
 - Allow overriding cell length when calculating s-matrix
 
-[Changes][0.5.5]
-
-
 <a id="0.5.4"></a>
 # [0.5.4](https://github.com/gdsfactory/meow/releases/tag/0.5.4) - 2023-06-09
-
-# What's Changed
 
 ## New
 
 - Add pml filtering function
 
-[Changes][0.5.4]
-
-
 <a id="0.5.3"></a>
 # [0.5.3](https://github.com/gdsfactory/meow/releases/tag/0.5.3) - 2023-06-09
-
-# What's Changed
 
 ## Bug Fixes
 
 - Make it possible to patch in custom visualization functions into mw.visualize/mw.vis
 - Attempt to fix github workflows
 
-[Changes][0.5.3]
-
-
 <a id="0.5.2"></a>
 # [0.5.2](https://github.com/gdsfactory/meow/releases/tag/0.5.2) - 2023-06-08
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -554,25 +396,15 @@
 
 - Allow phase keyword for S, pm visualization
 
-[Changes][0.5.2]
-
-
 <a id="0.5.1"></a>
 # [0.5.1](https://github.com/gdsfactory/meow/releases/tag/0.5.1) - 2023-06-07
-
-# What's Changed
 
 ## Maintenance
 
 - Improve visualization functions
 
-[Changes][0.5.1]
-
-
 <a id="0.5.0"></a>
 # [0.5.0](https://github.com/gdsfactory/meow/releases/tag/0.5.0) - 2023-06-07
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -583,49 +415,29 @@
 - Ensure reciprocity should not involve a hermitian transpose
 - Don't take real part when using unconjugated
 
-[Changes][0.5.0]
-
-
 <a id="0.4.3"></a>
 # [0.4.3](https://github.com/gdsfactory/meow/releases/tag/0.4.3) - 2023-06-06
-
-# What's Changed
 
 ## Other changes
 
 - Increase json serialization accuracy
 
-[Changes][0.4.3]
-
-
 <a id="0.4.2"></a>
 # [0.4.2](https://github.com/gdsfactory/meow/releases/tag/0.4.2) - 2023-06-06
-
-# What's Changed
 
 ## Other changes
 
 - Minor rewrite of compute_modes
 
-[Changes][0.4.2]
-
-
 <a id="0.4.1"></a>
 # [0.4.1](https://github.com/gdsfactory/meow/releases/tag/0.4.1) - 2023-06-05
-
-# What's Changed
 
 ## Other changes
 
 - Default to double precision for tidy3d fde
 
-[Changes][0.4.1]
-
-
 <a id="0.4.0"></a>
 # [0.4.0](https://github.com/gdsfactory/meow/releases/tag/0.4.0) - 2023-06-05
-
-# What's Changed
 
 ## Maintenance
 
@@ -635,74 +447,44 @@
 
 - Allow setting bend_radius to None
 
-[Changes][0.4.0]
-
-
 <a id="0.3.11"></a>
 # [0.3.11](https://github.com/gdsfactory/meow/releases/tag/0.3.11) - 2023-06-05
-
-# What's Changed
 
 ## Other changes
 
 - Ignore UserWarnings when plotting mode contours
 
-[Changes][0.3.11]
-
-
 <a id="0.3.10"></a>
 # [0.3.10](https://github.com/gdsfactory/meow/releases/tag/0.3.10) - 2023-06-05
-
-# What's Changed
 
 ## Other changes
 
 - Ignore RuntimeWarnings when doing shapely intersections
 
-[Changes][0.3.10]
-
-
 <a id="0.3.9"></a>
 # [0.3.9](https://github.com/gdsfactory/meow/releases/tag/0.3.9) - 2023-06-05
-
-# What's Changed
 
 ## Other changes
 
 - Fall back on gdspy if shapely has difficulties extruding polygon
 - Mmi
 
-[Changes][0.3.9]
-
-
 <a id="0.3.8"></a>
 # [0.3.8](https://github.com/gdsfactory/meow/releases/tag/0.3.8) - 2023-06-05
-
-# What's Changed
 
 ## Bug Fixes
 
 - Fix some typing issues
 
-[Changes][0.3.8]
-
-
 <a id="0.3.7"></a>
 # [0.3.7](https://github.com/gdsfactory/meow/releases/tag/0.3.7) - 2023-06-05
-
-# What's Changed
 
 ## Bug Fixes
 
 - Fix imports and revert zero_phase function
 
-[Changes][0.3.7]
-
-
 <a id="0.3.6"></a>
 # [0.3.6](https://github.com/gdsfactory/meow/releases/tag/0.3.6) - 2023-06-05
-
-# What's Changed
 
 ## New
 
@@ -738,13 +520,8 @@
 - Just use condaforge/mambaforge container for workflows
 - Correct Typo `i->j`
 
-[Changes][0.3.6]
-
-
 <a id="0.3.5"></a>
 # [0.3.5](https://github.com/gdsfactory/meow/releases/tag/0.3.5) - 2023-06-01
-
-# What's Changed
 
 ## Other changes
 
@@ -752,13 +529,8 @@
 - Allow interface matrix calc for diff num of modes
 - Convenience functions for Mode arithmetics
 
-[Changes][0.3.5]
-
-
 <a id="0.3.4"></a>
 # [0.3.4](https://github.com/gdsfactory/meow/releases/tag/0.3.4) - 2023-05-24
-
-# What's Changed
 
 ## New
 
@@ -774,49 +546,29 @@
 - Check tidy3d Version
 - Fill in zero valued off-diagonal epsilon
 
-[Changes][0.3.4]
-
-
 <a id="0.3.3"></a>
 # [0.3.3](https://github.com/gdsfactory/meow/releases/tag/0.3.3) - 2023-05-24
-
-# What's Changed
 
 ## Maintenance
 
 - Improve extrusions
 
-[Changes][0.3.3]
-
-
 <a id="0.3.2"></a>
 # [0.3.2](https://github.com/gdsfactory/meow/releases/tag/0.3.2) - 2023-05-23
-
-# What's Changed
 
 ## Maintenance
 
 - Slightly clean up compute_s_matrix_sax
 
-[Changes][0.3.2]
-
-
 <a id="0.3.1"></a>
 # [0.3.1](https://github.com/gdsfactory/meow/releases/tag/0.3.1) - 2023-05-23
-
-# What's Changed
 
 ## Other changes
 
 - Propagations should not take absolute value
 
-[Changes][0.3.1]
-
-
 <a id="0.3.0"></a>
 # [0.3.0](https://github.com/gdsfactory/meow/releases/tag/0.3.0) - 2023-05-18
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -826,37 +578,22 @@
 
 - Make matplotlib and trimesh kind-off optional dependencies
 
-[Changes][0.3.0]
-
-
 <a id="0.2.0"></a>
 # [0.2.0](https://github.com/gdsfactory/meow/releases/tag/0.2.0) - 2023-04-24
-
-# What's Changed
 
 ## Dependency Updates
 
 - Clean up dependencies
 
-[Changes][0.2.0]
-
-
 <a id="0.1.5"></a>
 # [0.1.5](https://github.com/gdsfactory/meow/releases/tag/0.1.5) - 2023-04-04
-
-# What's Changed
 
 ## Dependency Updates
 
 - Pin tidy3d to version > 2
 
-[Changes][0.1.5]
-
-
 <a id="0.1.4"></a>
 # [0.1.4](https://github.com/gdsfactory/meow/releases/tag/0.1.4) - 2023-04-04
-
-# What's Changed
 
 ## New
 
@@ -881,38 +618,23 @@
 - Include Poynting Vector calculation
 - Switch from tidy3d-beta to tidy3d
 
-[Changes][0.1.4]
-
-
 <a id="0.1.3"></a>
 # [0.1.3](https://github.com/gdsfactory/meow/releases/tag/0.1.3) - 2022-11-30
-
-# What's Changed
 
 ## Bug Fixes
 
 - Fix complex number deserialization
 
-[Changes][0.1.3]
-
-
 <a id="0.1.2"></a>
 # [0.1.2](https://github.com/gdsfactory/meow/releases/tag/0.1.2) - 2022-11-23
-
-# What's Changed
 
 ## Other changes
 
 - Don't sort modes by default
 - Enable cache by default
 
-[Changes][0.1.2]
-
-
 <a id="0.1.1"></a>
 # [0.1.1](https://github.com/gdsfactory/meow/releases/tag/0.1.1) - 2022-11-23
-
-# What's Changed
 
 ## New
 
@@ -922,37 +644,22 @@
 
 - Disable cache by default
 
-[Changes][0.1.1]
-
-
 <a id="0.1.0"></a>
 # [0.1.0](https://github.com/gdsfactory/meow/releases/tag/0.1.0) - 2022-11-19
-
-# What's Changed
 
 ## Other changes
 
 - Specify conformal settings as part of mesh settings
 
-[Changes][0.1.0]
-
-
 <a id="0.0.10"></a>
 # [0.0.10](https://github.com/gdsfactory/meow/releases/tag/0.0.10) - 2022-11-18
-
-# What's Changed
 
 ## Maintenance
 
 - Improve serialization again
 
-[Changes][0.0.10]
-
-
 <a id="0.0.9"></a>
 # [0.0.9](https://github.com/gdsfactory/meow/releases/tag/0.0.9) - 2022-11-17
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -962,49 +669,29 @@
 
 - Keep derived variables truly hidden
 
-[Changes][0.0.9]
-
-
 <a id="0.0.8"></a>
 # [0.0.8](https://github.com/gdsfactory/meow/releases/tag/0.0.8) - 2022-11-17
-
-# What's Changed
 
 ## Other changes
 
 - Ensure models have json schema
 
-[Changes][0.0.8]
-
-
 <a id="0.0.7"></a>
 # [0.0.7](https://github.com/gdsfactory/meow/releases/tag/0.0.7) - 2022-11-15
-
-# What's Changed
 
 ## Bug Fixes
 
 - Fix multi-dimensional material parsing
 
-[Changes][0.0.7]
-
-
 <a id="0.0.6"></a>
 # [0.0.6](https://github.com/gdsfactory/meow/releases/tag/0.0.6) - 2022-11-13
-
-# What's Changed
 
 ## Dependency Updates
 
 - Update requirements
 
-[Changes][0.0.6]
-
-
 <a id="0.0.5"></a>
 # [0.0.5](https://github.com/gdsfactory/meow/releases/tag/0.0.5) - 2022-11-11
-
-# What's Changed
 
 ## Other changes
 
@@ -1012,13 +699,8 @@
 - Don't track nbs_fail folder
 - Use correct version of myst_nb
 
-[Changes][0.0.5]
-
-
 <a id="0.0.4"></a>
 # [0.0.4](https://github.com/gdsfactory/meow/releases/tag/0.0.4) - 2022-11-11
-
-# What's Changed
 
 ## Bug Fixes
 
@@ -1036,13 +718,8 @@
 
 - Make te-fraction an easy to access property of a mode.
 
-[Changes][0.0.4]
-
-
 <a id="0.0.3"></a>
 # [0.0.3](https://github.com/gdsfactory/meow/releases/tag/0.0.3) - 2022-11-10
-
-# What's Changed
 
 ## Documentation
 
@@ -1054,13 +731,8 @@
 - Use latest tidy3d version
 - Use latest sax version
 
-[Changes][0.0.3]
-
-
 <a id="0.0.2"></a>
 # [0.0.2](https://github.com/gdsfactory/meow/releases/tag/0.0.2) - 2022-11-10
-
-# What's Changed
 
 ## New
 
@@ -1076,13 +748,8 @@
 
 - Update readme
 
-[Changes][0.0.2]
-
-
 <a id="0.0.1"></a>
 # [0.0.1](https://github.com/gdsfactory/meow/releases/tag/0.0.1) - 2022-11-09
-
-# What's Changed
 
 ## New
 
@@ -1110,75 +777,5 @@
 
 - Remove wrong import
 - Meow
-
-[Changes][0.0.1]
-
-
-[0.15.0]: https://github.com/gdsfactory/meow/compare/0.14.1...0.15.0
-[0.14.1]: https://github.com/gdsfactory/meow/compare/0.14.0...0.14.1
-[0.14.0]: https://github.com/gdsfactory/meow/compare/0.13.0...0.14.0
-[0.13.0]: https://github.com/gdsfactory/meow/compare/0.12.0...0.13.0
-[0.12.0]: https://github.com/gdsfactory/meow/compare/0.11.2...0.12.0
-[0.11.2]: https://github.com/gdsfactory/meow/compare/0.11.1...0.11.2
-[0.11.1]: https://github.com/gdsfactory/meow/compare/0.11.0...0.11.1
-[0.11.0]: https://github.com/gdsfactory/meow/compare/0.10.0...0.11.0
-[0.10.0]: https://github.com/gdsfactory/meow/compare/0.9.0...0.10.0
-[0.9.0]: https://github.com/gdsfactory/meow/compare/0.8.1...0.9.0
-[0.8.1]: https://github.com/gdsfactory/meow/compare/0.8.0...0.8.1
-[0.8.0]: https://github.com/gdsfactory/meow/compare/0.7.3...0.8.0
-[0.7.3]: https://github.com/gdsfactory/meow/compare/0.7.2...0.7.3
-[0.7.2]: https://github.com/gdsfactory/meow/compare/0.7.1...0.7.2
-[0.7.1]: https://github.com/gdsfactory/meow/compare/0.7.0...0.7.1
-[0.7.0]: https://github.com/gdsfactory/meow/compare/0.6.9...0.7.0
-[0.6.9]: https://github.com/gdsfactory/meow/compare/0.6.8...0.6.9
-[0.6.8]: https://github.com/gdsfactory/meow/compare/0.6.7...0.6.8
-[0.6.7]: https://github.com/gdsfactory/meow/compare/0.6.6...0.6.7
-[0.6.6]: https://github.com/gdsfactory/meow/compare/0.6.5...0.6.6
-[0.6.5]: https://github.com/gdsfactory/meow/compare/0.6.4...0.6.5
-[0.6.4]: https://github.com/gdsfactory/meow/compare/0.6.3...0.6.4
-[0.6.3]: https://github.com/gdsfactory/meow/compare/0.6.2...0.6.3
-[0.6.2]: https://github.com/gdsfactory/meow/compare/0.6.1...0.6.2
-[0.6.1]: https://github.com/gdsfactory/meow/compare/0.6.0...0.6.1
-[0.6.0]: https://github.com/gdsfactory/meow/compare/0.5.6...0.6.0
-[0.5.6]: https://github.com/gdsfactory/meow/compare/0.5.5...0.5.6
-[0.5.5]: https://github.com/gdsfactory/meow/compare/0.5.4...0.5.5
-[0.5.4]: https://github.com/gdsfactory/meow/compare/0.5.3...0.5.4
-[0.5.3]: https://github.com/gdsfactory/meow/compare/0.5.2...0.5.3
-[0.5.2]: https://github.com/gdsfactory/meow/compare/0.5.1...0.5.2
-[0.5.1]: https://github.com/gdsfactory/meow/compare/0.5.0...0.5.1
-[0.5.0]: https://github.com/gdsfactory/meow/compare/0.4.3...0.5.0
-[0.4.3]: https://github.com/gdsfactory/meow/compare/0.4.2...0.4.3
-[0.4.2]: https://github.com/gdsfactory/meow/compare/0.4.1...0.4.2
-[0.4.1]: https://github.com/gdsfactory/meow/compare/0.4.0...0.4.1
-[0.4.0]: https://github.com/gdsfactory/meow/compare/0.3.11...0.4.0
-[0.3.11]: https://github.com/gdsfactory/meow/compare/0.3.10...0.3.11
-[0.3.10]: https://github.com/gdsfactory/meow/compare/0.3.9...0.3.10
-[0.3.9]: https://github.com/gdsfactory/meow/compare/0.3.8...0.3.9
-[0.3.8]: https://github.com/gdsfactory/meow/compare/0.3.7...0.3.8
-[0.3.7]: https://github.com/gdsfactory/meow/compare/0.3.6...0.3.7
-[0.3.6]: https://github.com/gdsfactory/meow/compare/0.3.5...0.3.6
-[0.3.5]: https://github.com/gdsfactory/meow/compare/0.3.4...0.3.5
-[0.3.4]: https://github.com/gdsfactory/meow/compare/0.3.3...0.3.4
-[0.3.3]: https://github.com/gdsfactory/meow/compare/0.3.2...0.3.3
-[0.3.2]: https://github.com/gdsfactory/meow/compare/0.3.1...0.3.2
-[0.3.1]: https://github.com/gdsfactory/meow/compare/0.3.0...0.3.1
-[0.3.0]: https://github.com/gdsfactory/meow/compare/0.2.0...0.3.0
-[0.2.0]: https://github.com/gdsfactory/meow/compare/0.1.5...0.2.0
-[0.1.5]: https://github.com/gdsfactory/meow/compare/0.1.4...0.1.5
-[0.1.4]: https://github.com/gdsfactory/meow/compare/0.1.3...0.1.4
-[0.1.3]: https://github.com/gdsfactory/meow/compare/0.1.2...0.1.3
-[0.1.2]: https://github.com/gdsfactory/meow/compare/0.1.1...0.1.2
-[0.1.1]: https://github.com/gdsfactory/meow/compare/0.1.0...0.1.1
-[0.1.0]: https://github.com/gdsfactory/meow/compare/0.0.10...0.1.0
-[0.0.10]: https://github.com/gdsfactory/meow/compare/0.0.9...0.0.10
-[0.0.9]: https://github.com/gdsfactory/meow/compare/0.0.8...0.0.9
-[0.0.8]: https://github.com/gdsfactory/meow/compare/0.0.7...0.0.8
-[0.0.7]: https://github.com/gdsfactory/meow/compare/0.0.6...0.0.7
-[0.0.6]: https://github.com/gdsfactory/meow/compare/0.0.5...0.0.6
-[0.0.5]: https://github.com/gdsfactory/meow/compare/0.0.4...0.0.5
-[0.0.4]: https://github.com/gdsfactory/meow/compare/0.0.3...0.0.4
-[0.0.3]: https://github.com/gdsfactory/meow/compare/0.0.2...0.0.3
-[0.0.2]: https://github.com/gdsfactory/meow/compare/0.0.1...0.0.2
-[0.0.1]: https://github.com/gdsfactory/meow/tree/0.0.1
 
 <!-- Generated by https://github.com/rhysd/changelog-from-release v3.9.1 -->

--- a/src/meow/materials.py
+++ b/src/meow/materials.py
@@ -39,7 +39,7 @@ class MaterialBase(BaseModel):
         raise NotImplementedError(msg)
 
     def _lumadd(self, sim: Any, env: Environment, unit: float) -> str:
-        from matplotlib.cm import get_cmap
+        import matplotlib as mpl
 
         n = self(env)
         wl = np.asarray(env.wl * unit, dtype=complex).ravel()
@@ -49,7 +49,7 @@ class MaterialBase(BaseModel):
         if not sim.materialexists(self.name):
             sim.setmaterial(sim.addmaterial("Sampled data"), "name", self.name)
             color = np.asarray(
-                self.meta.get("color") or get_cmap("jet")(np.abs(eps) / 15.0)
+                self.meta.get("color") or mpl.colormaps["jet"](np.abs(eps) / 15.0)
             )
             sim.setmaterial(self.name, "color", color)
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -30,9 +30,6 @@ site_description = "Modeling of Eigenmodes and Overlaps in Waveguides"
 site_name = "meow"
 site_url = "https://gdsfactory.github.io/meow"
 
-[project.markdown_extensions.pymdownx.arithmatex]
-generic = true
-
 [project.plugins.mkdocstrings.handlers.python]
 inventories = [
   "https://docs.jax.dev/en/latest/objects.inv",


### PR DESCRIPTION
## Summary
- **Fix notebook code blocks**: remove `[project.markdown_extensions.pymdownx.arithmatex]` from `zensical.toml` — this was overriding all default markdown extensions (including `pymdownx.superfences` for fenced code blocks and `pymdownx.highlight` for syntax highlighting). Since `arithmatex` with `generic = true` is already in zensical's defaults, this section was redundant and caused all code fences on notebook pages to render as plain text.
- **Clean up changelog**: remove noisy `# What's Changed` headings, `**Full Changelog**: ...` links, `[Changes][x.y.z]` references, unused reference-link definitions, and fix `$OWNER/$REPOSITORY` placeholders.

Closes #60

## Test plan
- [ ] Run `just dev nbdocs docs` and verify code blocks render correctly on the quickstart page
- [ ] Verify changelog page renders cleanly without the noise lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)